### PR TITLE
moves to git directory before getting pr number

### DIFF
--- a/.github/workflows/repository-deployment.yml
+++ b/.github/workflows/repository-deployment.yml
@@ -78,6 +78,7 @@ jobs:
           fi
           DOWNLOAD_SRC=http://172.21.7.2/github/ovirt-engine/commits/${{ steps.vars.outputs.COMMIT }}/
           if [ ${{ steps.vars.outputs.IS_MERGE }} == 'true' ]; then
+            cd ${{ steps.vars.outputs.TARGET_DIR }}
             PR_NUMBER=`git log --merges -n 1 | grep "Merge pull request" | sed -n "s/^.*Merge pull request #\\s*\\([0-9]*\\).*$/\\1/p"`
             DOWNLOAD_SRC=http://172.21.7.2/github/ovirt-engine/pull-requests/${PR_NUMBER}/
           fi


### PR DESCRIPTION
- deploy 과정중 PR number를 가져오기 위해 git 명령어를 사용하는데, git directory로 이동하지 않고 해당 명령어를 수행하여 error가 발생하던 문제를 해결함