### PR TITLE
[IMS] 279623 CLI환경에서 사용자 정보 편집 시 UI에 반영되지 않는 현상

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/aaa/AddUserCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/aaa/AddUserCommand.java
@@ -46,6 +46,7 @@ public class AddUserCommand<T extends AddUserParameters> extends CommandBase<T> 
         } else {
             user.setId(userFromDb.getId());
             dbUserDao.update(user);
+	    dbUserDao.updateLastAdminCheckStatus(user.getId());
         }
         setActionReturnValue(user.getId());
         setSucceeded(true);


### PR DESCRIPTION
- 사용자 아이콘이 변경되는 현상 수정
원인은 admin 권한 여부를 확인하는 last_admin_check_status 값을 이미
존재하는 사용자에 대해 다시 추가할 때 검사/갱신해주지 않고 기본 값인 false로 설정하기 때문이었음. 해당 last_admin_check_status 값을 다시 갱신해주는 구문 삽입하여 해결.